### PR TITLE
Do not create consumer group when reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ kafkadog -t my-topic
 # Consume messages from a specific broker
 kafkadog -b kafka-broker:9092 -t my-topic
 
-# Use a specific consumer group
-kafkadog -b kafka-broker:9092 -t my-topic -G my-consumer-group
-
 # Start consuming from the beginning of the topic
 kafkadog -t my-topic -o beginning
 
@@ -107,7 +104,7 @@ kafkadog -t protobuf-topic -proto -f hex
 
 ```bash
 # Consume messages from a remote broker, decode as protobuf, and output as raw text
-kafkadog -b remote-kafka:9092 -t events -G analytics-group -proto
+kafkadog -b remote-kafka:9092 -t events -proto
 
 # Consume only 50 messages, decode as protobuf, and display in hex format
 kafkadog -b remote-kafka:9092 -t binary-events -proto -f hex -c 50
@@ -128,7 +125,6 @@ cat binary-data.hex | kafkadog -b kafka-broker:9092 -t binary-topic -P -f hex
 |--------|-------------|
 | `-b` | Kafka broker(s) separated by commas (default: "localhost:9092") |
 | `-t` | Topic to produce to or consume from (required) |
-| `-G` | Consumer group ID (default: "kafkadog") |
 | `-f` | Format: raw, hex, base64 (default: "raw") |
 | `-P` | Producer mode - read from stdin and send to Kafka |
 | `-C` | Consumer mode - read from Kafka and write to stdout (default if neither -P nor -C specified) |

--- a/cmd/kafkadog/kafkadog.go
+++ b/cmd/kafkadog/kafkadog.go
@@ -30,31 +30,31 @@ func main() {
 	if cfg.ConsumeMode {
 		// Prepare the offset based on the config
 		var kafkaOffset kgo.Offset
-		switch cfg.ConsumerOffset {
-		case "beginning":
-			kafkaOffset = kgo.NewOffset().AtStart()
-		case "end":
-			kafkaOffset = kgo.NewOffset().AtEnd()
-		default:
-			// Try to parse as integer
-			if offsetVal, err := strconv.ParseInt(cfg.ConsumerOffset, 10, 64); err == nil {
-				if offsetVal < 0 {
-					// Negative value means relative offset from end
-					kafkaOffset = kgo.NewOffset().Relative(offsetVal)
-				} else {
-					// Non-negative value is an absolute offset
-					kafkaOffset = kgo.NewOffset().At(offsetVal)
-				}
-			} else {
-				fmt.Fprintf(os.Stderr, "Warning: Invalid offset value '%s', defaulting to beginning\n", cfg.ConsumerOffset)
+			switch cfg.ConsumerOffset {
+			case "beginning":
+				kafkaOffset = kgo.NewOffset().AtStart()
+			case "end":
 				kafkaOffset = kgo.NewOffset().AtEnd()
+			default:
+				// Try to parse as integer
+				if offsetVal, err := strconv.ParseInt(cfg.ConsumerOffset, 10, 64); err == nil {
+					if offsetVal < 0 {
+						// Negative value means relative offset from end
+						kafkaOffset = kgo.NewOffset().Relative(offsetVal)
+					} else {
+						// Non-negative value is an absolute offset
+						kafkaOffset = kgo.NewOffset().At(offsetVal)
+					}
+				} else {
+				fmt.Fprintf(os.Stderr, "Warning: Invalid offset value '%s', defaulting to beginning\n", cfg.ConsumerOffset)
+					kafkaOffset = kgo.NewOffset().AtEnd()
 			}
 		}
 
 		opts = append(opts,
-			kgo.ConsumerGroup(cfg.ConsumerGroup),
 			kgo.ConsumeTopics(cfg.Topic),
 			kgo.ConsumeResetOffset(kafkaOffset),
+			kgo.ConsumerGroup(""), // Empty group ID prevents joining a consumer group
 		)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,6 @@ type Format string
 type Config struct {
 	Brokers        []string
 	Topic          string
-	ConsumerGroup  string
 	ProduceMode    bool
 	ConsumeMode    bool
 	Format         Format
@@ -29,7 +28,6 @@ func Parse() (*Config, error) {
 	var (
 		brokers        string
 		topic          string
-		consumerGroup  string
 		format         string
 		produceMode    bool
 		consumeMode    bool
@@ -43,7 +41,6 @@ func Parse() (*Config, error) {
 
 	flag.StringVar(&brokers, "b", "localhost:9092", "Kafka broker(s) separated by commas")
 	flag.StringVar(&topic, "t", "", "Topic to produce to or consume from")
-	flag.StringVar(&consumerGroup, "G", "kafkadog", "Consumer group ID (for consume mode)")
 	flag.StringVar(&format, "f", "raw", formatUsage)
 	flag.BoolVar(&produceMode, "P", false, "Producer mode - read from stdin and send to Kafka")
 	flag.BoolVar(&consumeMode, "C", false, "Consumer mode - read from Kafka and write to stdout")
@@ -75,7 +72,6 @@ func Parse() (*Config, error) {
 	return &Config{
 		Brokers:        strings.Split(brokers, ","),
 		Topic:          topic,
-		ConsumerGroup:  consumerGroup,
 		ProduceMode:    produceMode,
 		ConsumeMode:    consumeMode,
 		Format:         Format(format),


### PR DESCRIPTION
# What
- Do not create consumer group when consuming

# Why
- Main use case for app is debugging, and should not pollute clusters with extra groups
- Also ACLs might prevent creating consumer groups, thus preventing consuming